### PR TITLE
Requires on vhost creates dependency cycle

### DIFF
--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -12,7 +12,6 @@ class puppetexplorer::apache {
     port            => $::puppetexplorer::port,
     proxy_pass      => $::puppetexplorer::proxy_pass,
     ssl_proxyengine => true,
-    require         => Class['apache'],
   }
 
   create_resources ('apache::vhost', hash([$::puppetexplorer::servername, $base_vhost_options]), $::puppetexplorer::vhost_options)


### PR DESCRIPTION
The vhost defined type from puppetlabs-apache already requires/notifies the
appropriate resources.

Error: Could not apply complete catalog: Found 1 dependency cycle:
(Exec[concat_25-puppetdb.example.com.conf] => File[25-puppetdb.example.com.conf] =>
File[25-puppetdb.example.com.conf symlink] =>
Apache::Vhost[puppetdb.example.com] =>
Class[Puppetexplorer::Apache] => Apache::Vhost[puppetdb.example.com] =>
File[25-puppetdb.example.com.conf symlink])