### PR TITLE
Update apt key to full 40characters

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -147,7 +147,7 @@ class puppetexplorer (
       location    => 'http://apt.puppetexplorer.io',
       release     => 'stable',
       repos       => 'main',
-      key         => '3FF5E93D',
+      key         => 'CA37C758D0D8CD3AE9740C466F75C6183FF5E93D',
       include_src => false,
     }
   }


### PR DESCRIPTION
Latest version of puppetlabs/apt module shows warning on every puppet run (Warning: /Apt_key[Add key: 3FF5E93D from Apt::Source puppetexplorer]: The id should be a full fingerprint (40 characters), see README.) if using a short key so this update includes the full 40 character key.