### PR TITLE
make metadata.json play nice with librarian-puppet

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -9,15 +9,15 @@
   "issues_url": "https://github.com/spotify/puppet-puppetexplorer/issues",
   "dependencies": [
     {
-      "name": "puppetlabs-apache",
+      "name": "puppetlabs/apache",
       "version_requirement": ">= 1.0.0"
     },
     {
-      "name": "puppetlabs-stdlib",
+      "name": "puppetlabs/stdlib",
       "version_requirement": ">= 1.0.0"
     },
     {
-      "name": "puppetlabs-apt",
+      "name": "puppetlabs/apt",
       "version_requirement": ">= 1.0.0"
     }
   ]


### PR DESCRIPTION
currently librarian-puppet update doesnt succeed, due to the following error

.tmp/librarian/cache/source/puppet/forge/forgeapi_puppetlabs_com/puppetlabs-apache/1.4.0/puppetlabs-apache does not exist, something went wrong. Try removing it manually.

Implementing this proposed change will make librarian-puppet play nice again