### PR TITLE
Bumped version for Puppet forge to recognize recent merge

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "spotify-puppetexplorer",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": "spotify",
   "summary": "Manage the Puppet Explorer web application",
   "license": "Apache-2.0",


### PR DESCRIPTION
When pulling from Puppet forge (with librarian-puppet for example) and requesting latest version, you get 1.0.1, but that doesn't reflect the latest merge (meaning ordering is wrong on debian systems). I've bumped the version in metadata and tagged the commit with 1.0.2.