### PR TITLE
Add ssl_proxyengine configuration option

### DIFF
--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -11,7 +11,7 @@ class puppetexplorer::apache {
     ssl             => $::puppetexplorer::ssl,
     port            => $::puppetexplorer::port,
     proxy_pass      => $::puppetexplorer::proxy_pass,
-    ssl_proxyengine => true,
+    ssl_proxyengine => $::puppetexplorer::ssl_proxyengine,
   }
 
   create_resources ('apache::vhost', hash([$::puppetexplorer::servername, $base_vhost_options]), $::puppetexplorer::vhost_options)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -83,6 +83,10 @@
 #       { 'path' => '/api/metrics', 'url'   => 'http://localhost:8080/metrics' }
 #     ]
 #
+# [*ssl_proxyengine*]
+#   Specifies whether or not to use SSLProxyEngine in the vhost.
+#   Valid values are 'true' and 'false'. Default: true
+#
 # [*vhost_options*]
 #   An additional hash of apache::vhost options, see puppetlabs-apache for more
 #   info. Can be used for configuring authentication or SSL certificates for
@@ -148,6 +152,7 @@ class puppetexplorer (
     { 'path' => '/api/pdb/meta', 'url' => 'http://localhost:8080/pdb/meta' },
     { 'path' => '/api/metrics', 'url' => 'http://localhost:8080/metrics' }
   ],
+  $ssl_proxyengine    = true,
   $vhost_options      = {},
 ) {
 


### PR DESCRIPTION
This commit add the ability to override the ssl_proxyengine of the
vhost class.

We hit a problem with this since upstream puppetlabs-apache commit
https://github.com/puppetlabs/puppetlabs-apache/commit/1fb2b8af2e3e9f7b3f5ff280c47bc90c01c65edc

Before that upstream commit, the SSLProxyEngine directive was only
enabled when "ssl" was set to true.