### PR TITLE
removing include_src => false as that parameter is not part of the ap…

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -170,7 +170,6 @@ class puppetexplorer (
       release     => 'stable',
       repos       => 'main',
       key         => 'CA37C758D0D8CD3AE9740C466F75C6183FF5E93D',
-      include_src => false,
       before      => Package['puppetexplorer'],
     }
   }


### PR DESCRIPTION
…t module any longer.

This parameter has changed in newer versions of the apt module and is no longer needed for proper usage.